### PR TITLE
add configuration path searching

### DIFF
--- a/sparkmanager/config.py
+++ b/sparkmanager/config.py
@@ -1,0 +1,53 @@
+from jupyter_core.paths import jupyter_config_path
+import os
+from glob import glob
+import json
+
+def sparkmanager_config_path():
+    """
+    Gets all paths on the system that could store configuration files. 
+    These paths are derived from those used by jupyter in addition to the module path 
+    """
+    module_path = os.path.dirname(os.path.abspath(__file__))
+    jupyter_paths = jupyter_config_path()
+    sparkmanager_paths = [c.replace("jupyter", "sparkmanager") for c in jupyter_paths] + [module_path]
+    return sparkmanager_paths
+
+def get_cluster_config_paths():
+    """
+    Appends "clusters" to the sparkmanager configuration paths
+    """
+    paths = sparkmanager_config_path()
+    cluster_paths = [os.path.join(path, "clusters") for path in paths]
+    return cluster_paths
+
+def get_cluster_config_files():
+    """
+    Searches for JSON files in the clusters directories in the sparkmanager configuration directories 
+    """
+    paths = get_cluster_config_paths()
+
+    cluster_configs = []
+
+    for path in paths:
+        clusters = glob(os.path.join(path, "*"))
+        for cluster in clusters:
+            json_path = os.path.join(cluster, "cluster.json")
+            if os.path.exists(json_path):
+                print("found cluster:", json_path)
+                cluster_configs.append(json_path)
+    
+    return cluster_configs
+
+def get_cluster_configs():
+    """
+    Loads the cluster configuration JSON files into memory
+    """
+    configs = {}
+    cluster_config_files = get_cluster_config_files()
+    for path in cluster_config_files:
+        with open(path, "r") as f:
+            config_values = json.load(f)
+        name = config_values.get('name')
+        configs[name] = config_values
+    return configs


### PR DESCRIPTION
Made an API for getting configuration paths and loading cluster configuration files in Python. Makes changes to server extension to use this API.

Paths searched for configurations are the same as Jupyter uses (`jupyter --paths`) with the addition of searching the module directory.

Configuration directory structure expected is e.g. `/usr/local/etc/sparkmanager/clusters/<cluster-name>/cluster.json`. Additionally, the `cluster.json` file should have a `name` field.

Demonstration:
```
(base) Stevens-MacBook-Pro:gsoc steven$ python
Python 3.7.3 (default, Mar 27 2019, 16:54:48) 
[Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from sparkmanager import config
>>> config.sparkmanager_config_path()
['/Users/steven/.sparkmanager', '/anaconda3/etc/sparkmanager', '/usr/local/etc/sparkmanager', '/etc/sparkmanager', '/anaconda3/lib/python3.7/site-packages/sparkmanager']
>>> config.get_cluster_config_paths()
['/Users/steven/.sparkmanager/clusters', '/anaconda3/etc/sparkmanager/clusters', '/usr/local/etc/sparkmanager/clusters', '/etc/sparkmanager/clusters', '/anaconda3/lib/python3.7/site-packages/sparkmanager/clusters']
>>> config.get_cluster_config_files()
found cluster: /Users/steven/.sparkmanager/clusters/axs/cluster.json
found cluster: /Users/steven/.sparkmanager/clusters/axs-eks/cluster.json
['/Users/steven/.sparkmanager/clusters/axs/cluster.json', '/Users/steven/.sparkmanager/clusters/axs-eks/cluster.json']
>>> config.get_cluster_configs()
found cluster: /Users/steven/.sparkmanager/clusters/axs/cluster.json
found cluster: /Users/steven/.sparkmanager/clusters/axs-eks/cluster.json
{'Local': {'conf': {'spark.driver.cores': '4', 'spark.driver.memory': '8g', 'spark.master': 'local[*]'}, 'name': 'Local', 'type': 'local'}, 'AWS': {'conf': {'spark.driver.cores': '4', 'spark.driver.memory': '8g', 'spark.executor.instances': 2}, 'name': 'AWS', 'type': 'kubernetes'}}
```