### PR TITLE
Python Core API

### DIFF
--- a/sparkmanager/__init__.py
+++ b/sparkmanager/__init__.py
@@ -1,3 +1,5 @@
+from .core import SparkCluster, SparkSession, SparkContext, get_clusters
+
 def _jupyter_nbextension_paths():
     """Used by 'jupyter nbextension' command to install frontend extension"""
     return [
@@ -12,10 +14,8 @@ def _jupyter_nbextension_paths():
 		)
 	]
 
-
 def _jupyter_server_extension_paths():
     """Used by "jupyter serverextension" command to install web server extension'"""
     return [{
         "module": "sparkmanager.serverextension"
     }]
-

--- a/sparkmanager/config.py
+++ b/sparkmanager/config.py
@@ -2,6 +2,7 @@ from jupyter_core.paths import jupyter_config_path
 import os
 from glob import glob
 import json
+from pyspark import SparkConf
 
 def sparkmanager_config_path():
     """
@@ -51,3 +52,22 @@ def get_cluster_configs():
         name = config_values.get('name')
         configs[name] = config_values
     return configs
+
+def _merge_conf(conf_1, conf_2):
+    ret_conf = SparkConf()
+    _fill_conf(dict(conf_1.getAll()), ret_conf)
+    _fill_conf(dict(conf_2.getAll()), ret_conf)
+    return ret_conf
+
+def _fill_conf(d, conf):
+    for key, value in d.items():
+        conf.set(key, value)
+
+def _get_conf(path):
+    with open(path, "r") as f:
+        cluster_info = json.load(f)['conf']
+        conf = SparkConf()
+
+        _fill_conf(cluster_info, conf)
+
+        return conf

--- a/sparkmanager/core.py
+++ b/sparkmanager/core.py
@@ -1,0 +1,86 @@
+from pyspark import SparkContext as _SparkContext, SparkConf
+from pyspark.sql import SparkSession as _SparkSession
+import os
+from .config import get_cluster_config_files
+
+def shut_down_jvm():
+    # get Java process, a subprocess.Popen object
+    proc = _SparkContext._gateway.proc
+
+    # remove the py4j gateway and JVM objects in Spark
+    _SparkContext._gateway = None
+    _SparkContext._jvm = None
+    _SparkSession._jvm = None
+
+    # send SIGTERM
+    proc.terminate()
+    # wait for process to return exit code, reaps zombie process
+    proc.wait()
+
+class SparkCluster():
+    def __init__(self, path):
+        self.path = path
+        self.conf_dir = os.path.join(os.path.dirname(self.path), "conf")
+
+class SparkContext(_SparkContext):
+    _cluster = None
+
+    def __init__(self, cluster=None, **kwargs):
+        SparkContext._cluster = cluster
+        if cluster:
+            cluster_file = cluster.path
+            conf_dir = cluster.conf_dir
+
+            print("Setting SPARK_CONF_DIR to", conf_dir)
+            os.environ['SPARK_CONF_DIR'] = conf_dir
+
+        super().__init__(**kwargs)
+
+    def stop(self):
+        # call _SparkContext.stop()
+        super().stop()
+
+        # get Spark py4j gateway
+        gateway = _SparkContext._gateway
+        # close the py4j gateway connections
+        gateway.close()
+        # shut down JVM
+        shut_down_jvm()
+    
+    @classmethod
+    def getOrCreate(cls, conf=None, cluster=None):
+        """
+        Get or instantiate a SparkContext and register it as a singleton object.
+        :param conf: SparkConf (optional)
+        """
+        with SparkContext._lock:
+            if SparkContext._active_spark_context is None:
+                SparkContext(conf=conf or SparkConf(), cluster=cluster)
+            return SparkContext._active_spark_context
+
+class SparkSession(_SparkSession):
+    class Builder(_SparkSession.Builder):
+        def getOrCreate(self, cluster=None):
+            SparkContext._cluster = cluster
+
+            sparkConf = SparkConf()
+            for key, value in self._options.items():
+                sparkConf.set(key, value)
+            # This SparkContext may be an existing one.
+            sc = SparkContext.getOrCreate(sparkConf, cluster=cluster)
+            self._sc = sc
+            return super().getOrCreate()
+    
+    builder = Builder()
+    
+    def stop(self):
+        self._jvm.SparkSession.clearDefaultSession()
+        self._jvm.SparkSession.clearActiveSession()
+        SparkSession._instantiatedSession = None
+        SparkSession._activeSession = None
+        self._sc.stop()
+
+def get_clusters():
+    cluster_files = get_cluster_config_files()
+    clusters = [SparkCluster(cluster_file) for cluster_file in cluster_files]
+    return clusters


### PR DESCRIPTION
Addresses https://github.com/astronomy-commons/sparkmanager/issues/6

The core API so far is just a wrapper around the `pyspark.SparkContext` and `pyspark.sql.SparkSession` python classes with modifications for how they are created (methods `pyspark.SparkContext.__init__` and  `pyspark.sql.SparkSession.Builder.getOrCreate`) and how they are stopped (methods `pyspark.SparkContext.stop` and `pyspark.sql.SparkSession.stop`). 

The start methods now switch the `SPARK_CONF_DIR` environment variable to a `conf` directory next to a cluster's `cluster.json` file. This allows cluster configurations to be picked up in `/path/to/cluster/conf/spark-defaults.conf` in addition to those set at runtime.

The stop methods now completely shutdown the JVM when called. This should fix the issue where changing certain configurations like `spark.driver.memory` to incorrect values (e.g. `spark.driver.memory=-4g`) after first creating a Spark Application doesn't cause an error, since the JVM created with the old `spark.driver.memory` value is  being re-used. This will also allow for `spark.driver.memory` to be changed to a correct value as well between calls to `stop`.